### PR TITLE
Rds config

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,6 +11,36 @@ on:
       - completed
 
 jobs:
+  check-for-terraform-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      terraform_changed: ${{ steps.check.outputs.terraform_changed }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Check if Terraform directory changed
+        id: check
+        run: |
+          if git diff --name-only HEAD^ HEAD | grep -q '^terraform/'; then
+            echo "Terraform directory changed."
+            echo "::set-output name=terraform_changed::true"
+          else
+            echo "No changes in the Terraform directory."
+            echo "::set-output name=terraform_changed::false"
+          fi
+  terraform-config:
+    needs: check-for-terraform-changes
+    runs-on: ubuntu-latest
+    if: ${{ needs.check-terraform-changes.outputs.terraform_changed == 'true' }}
+    uses: mikeheft/go-backend/.github/workflows/terraform.yaml@main # Calls the reusable Terraform workflow
+    with:
+      aws-region: "us-west-2"
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
   build-and-push:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -30,20 +30,14 @@ jobs:
             echo "No changes in the Terraform directory."
             echo "::set-output name=terraform_changed::false"
           fi
+
   terraform-config:
     needs: check-for-terraform-changes
-    runs-on: ubuntu-latest
-    if: ${{ needs.check-terraform-changes.outputs.terraform_changed == 'true' }}
+    if: ${{ needs.check-for-terraform-changes.outputs.terraform_changed == 'true' }}
     uses: mikeheft/go-backend/.github/workflows/terraform.yaml@main # Calls the reusable Terraform workflow
-    with:
-      aws-region: "us-west-2"
-    secrets:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   build-and-push:
     runs-on: ubuntu-latest
-
     # Only run if the terraform worflow was successful
     if: ${{ github.event.workflow_run.conclusion != 'failure' }}
 

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -1,12 +1,17 @@
 name: Terraform Plan and Apply
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "terraform/**" # Monitor changes in the terraform/ directory
-      - ".github/workflows/terraform.yaml" # Monitor changes to this workflow file
+  workflow_call: # This makes it reusable
+    inputs:
+      aws-region:
+        description: "AWS region for Terraform"
+        required: true
+        type: string
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
 
 jobs:
   terraform:
@@ -23,7 +28,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
+          aws-region: ${{ inputs.aws-region }}
 
       # Step 2: Set up Terraform
       - name: Setup Terraform

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -28,7 +28,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ inputs.aws-region }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
       # Step 2: Set up Terraform
       - name: Setup Terraform

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ migratedown:
 migratedown1:
 	migrate -path db/migration -database "postgresql://root:secret@localhost:54321/simple_bank?sslmode=disable" -verbose down 1
 postgres:
-	docker run --name postgres12 --network bank-network -p 54321:5432 -e POSTGRES_USER=root -e POSTGRES_PASSWORD=secret/password -d postgres:12-alpine
+	docker run --name postgres12 --network bank-network -p 54321:5432 -e POSTGRES_USER=root -e POSTGRES_PASSWORD=secret -d postgres:12-alpine
 server:
 	go run main.go
 sqlc:

--- a/terraform/rds/main.tf
+++ b/terraform/rds/main.tf
@@ -6,7 +6,7 @@ resource "aws_db_instance" "postgres" {
   instance_class    = "db.t3.micro"
   # Will be annonymized in actual prod project
   username               = "root"
-  password               = "secret/password"
+  password               = "secret-password"
   publicly_accessible    = false
   skip_final_snapshot    = true
   vpc_security_group_ids = var.rds_security_group_ids


### PR DESCRIPTION
Refactor calling the reusable workflow to not recall `runs-on`. This violates the syntax and makes it think it's using an inline job and not a reusable workflow